### PR TITLE
Fix: Add userAgent to HttpClient

### DIFF
--- a/dist/terrakube.js
+++ b/dist/terrakube.js
@@ -37,7 +37,7 @@ const core = __importStar(require("@actions/core"));
 const httpm = __importStar(require("@actions/http-client"));
 class TerrakubeClient {
     constructor(gitHubActionInput) {
-        this.httpClient = new httpm.HttpClient();
+        this.httpClient = new httpm.HttpClient("TerrakubeActionGithub");
         this.gitHubActionInput = gitHubActionInput;
         this.authenticationToken = 'empty';
         core.info(`Creating Terrakube CLient....`);

--- a/src/terrakube.ts
+++ b/src/terrakube.ts
@@ -9,7 +9,7 @@ export class TerrakubeClient {
     private gitHubActionInput: GitHubActionInput;
 
     constructor(gitHubActionInput: GitHubActionInput) {
-        this.httpClient = new httpm.HttpClient();
+        this.httpClient = new httpm.HttpClient("TerrakubeActionGithub");
         this.gitHubActionInput = gitHubActionInput;
         this.authenticationToken = 'empty'
 


### PR DESCRIPTION
This commit adds a User-Agent header to the HttpClient. Web Application Firewalls commonly have rules to block http requests missing this header.